### PR TITLE
fix(Footer): Correct the link to Elixir's Regex module and add 'noope…

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -58,9 +58,9 @@
         </ul>
         <p class="reference__more">
         For more information see the Elixir
-        <a href="http://elixir-lang.org/docs/v1.0/elixir/Regex.html" target="_blank">
+        <a href="https://hexdocs.pm/elixir/Regex.html" target="_blank" rel="noopener noreferrer">
           Regex documentation</a> and the Erlang
-        <a href="http://www.erlang.org/doc/man/re.html" target="_blank">re
+        <a href="http://www.erlang.org/doc/man/re.html" target="_blank" rel="noopener noreferrer">re
           documentation</a>.
         </p>
       </div>
@@ -69,23 +69,23 @@
     <footer class="footer">
       <p>
         Elix<span class="b">re</span> is
-        <a href="http://en.wikipedia.org/wiki/Free_software" target="_blank">
+        <a href="http://en.wikipedia.org/wiki/Free_software" target="_blank" rel="noopener noreferrer">
         Free software</a>, available under the
-        <a href="https://gnu.org/licenses/agpl.html" target="_blank">GNU
+        <a href="https://gnu.org/licenses/agpl.html" target="_blank" rel="noopener noreferrer">GNU
           AGPL3</a> licence.
       </p>
       <p>
         The source code is freely available on
-        <a href="http://github.com/lpil/elixre" target="_blank">GitHub</a>.
+        <a href="http://github.com/lpil/elixre" target="_blank" rel="noopener noreferrer">GitHub</a>.
         (Contributions welcome!)
       </p>
       <p>
         Inspired by Michael Lovitt's excellent
-        <a href="http://rubular.com/" target="_blank">Rubular</a>.
+        <a href="http://rubular.com/" target="_blank" rel="noopener noreferrer">Rubular</a>.
       </p>
       <p>
         Copyright © 2015 - Present
-        <a href="http://lpil.uk/" target="_blank">Louis Pilfold</a>. All Rights
+        <a href="http://lpil.uk/" target="_blank" rel="noopener noreferrer">Louis Pilfold</a>. All Rights
         Reserved.
       </p>
     </footer>


### PR DESCRIPTION
…ner norefferrer' to all target='_blank' links

Some small fixes to the main page of the site. Here is why I've added the additional rel attribute on target blank links: https://www.jitbit.com/alexblog/256-targetblank---the-most-underestimated-vulnerability-ever/